### PR TITLE
Fixed delta_fix parameter parsing

### DIFF
--- a/src/org/gesis/promoss/inference/Run.java
+++ b/src/org/gesis/promoss/inference/Run.java
@@ -63,7 +63,7 @@ public class Run {
 				else if (args[i].equals("-delta_fix")) {
 					String value = args[++i];
 					if (!value.equals("none")) {
-					hmdp.delta_fix = Double.valueOf(args[++i]);
+					hmdp.delta_fix = Double.valueOf(value);
 					}
 				}
 


### PR DESCRIPTION
If delta_fix was set the model crashed as it tried to parse the wrong argument.